### PR TITLE
Fix notice thrown when the index query is undefined

### DIFF
--- a/src/http_build_url.php
+++ b/src/http_build_url.php
@@ -62,7 +62,7 @@ if (!function_exists('http_build_url')) {
 		is_array($url) || $url = parse_url($url);
 		is_array($parts) || $parts = parse_url($parts);
 
-		is_string($url['query']) || $url['query'] = null;
+		isset($url['query']) && is_string($url['query']) || $url['query'] = null;
 		isset($parts['query']) && is_string($parts['query']) || $parts['query'] = null;
 
 		$keys = array('user', 'pass', 'port', 'path', 'query', 'fragment');


### PR DESCRIPTION
I get a notice thrown when no query string is provided in the original url, this should help mitigate it.
