### PR TITLE
Fix for the trailing slash when the "path" is empty

### DIFF
--- a/src/http_build_url.php
+++ b/src/http_build_url.php
@@ -149,7 +149,7 @@ if (!function_exists('http_build_url')) {
 			$parsed_string .= ':' . $url['port'];
 		}
 
-		if (isset($url['path'])) {
+		if (!empty($url['path'])) {
 			$parsed_string .= $url['path'];
 		} else {
 			$parsed_string .= '/';


### PR DESCRIPTION
This fix should allow to get:
http://test.loc/
instead of
http://test.loc
