### PR TITLE
Pecl http 1.7.x

### DIFF
--- a/src/http_build_url.php
+++ b/src/http_build_url.php
@@ -95,7 +95,7 @@ if (!function_exists('http_build_url')) {
 					// Workaround for trailing slashes
 					$url['path'] .= 'a';
 					$url['path'] = rtrim(
-							str_replace(basename($url['path']), '', $url['path']),
+							preg_replace('#' . basename($url['path']) . '$#', '', $url['path']),
 							'/'
 						) . '/' . ltrim($parts['path'], '/');
 				} else {

--- a/src/http_build_url.php
+++ b/src/http_build_url.php
@@ -103,8 +103,8 @@ if (!function_exists('http_build_url')) {
 				}
 			}
 
-			if (isset($parts['query']) && ($flags & HTTP_URL_JOIN_QUERY)) {
-				if (isset($url['query'])) {
+			if (isset($parts['query'])) {
+				if ($flags & HTTP_URL_JOIN_QUERY && isset($url['query'])) {
 					parse_str($url['query'], $url_query);
 					parse_str($parts['query'], $parts_query);
 

--- a/src/http_build_url.php
+++ b/src/http_build_url.php
@@ -156,6 +156,10 @@ if (!function_exists('http_build_url')) {
 		}
 
 		if (!empty($url['path'])) {
+			// Clean up any /foo/../bar or /foo/./bar
+			for ($n=1; $n>0;  $url['path'] = preg_replace(array('#(/\.?/)#', '#/(?!\.\.)[^/]+/\.\./#'), '/', $url['path'], -1, $n)) {}
+			// Clean up any /../bar
+			$url['path'] = preg_replace(array('#/\.\./#'), '/', $url['path']);
 			$parsed_string .= $url['path'];
 		} else {
 			$parsed_string .= '/';

--- a/src/http_build_url.php
+++ b/src/http_build_url.php
@@ -157,6 +157,8 @@ if (!function_exists('http_build_url')) {
 
 		if (!empty($url['path'])) {
 			$parsed_string .= $url['path'];
+		} else {
+			$parsed_string .= '/';
 		}
 
 		if (!empty($url['query'])) {

--- a/tests/HttpBuildUrlTest.php
+++ b/tests/HttpBuildUrlTest.php
@@ -30,14 +30,14 @@ class HttpBuildUrlTest extends \PHPUnit_Framework_TestCase
 	{
 		return array(
 			array(
-				'http://example.com',
+				'http://example.com/',
 				array(
 					'scheme' => 'http',
 					'host' => 'example.com'
 				)
 			),
 			array(
-				'http://example.com',
+				'http://example.com/',
 				array(
 					'scheme' => 'http',
 					'host' => 'example.com',
@@ -69,7 +69,7 @@ class HttpBuildUrlTest extends \PHPUnit_Framework_TestCase
 				)
 			),
 			array(
-				'http://example.com:81?a=b',
+				'http://example.com:81/?a=b',
 				array(
 					'scheme' => 'http',
 					'host' => 'example.com',
@@ -207,10 +207,10 @@ class HttpBuildUrlTest extends \PHPUnit_Framework_TestCase
 			array('HTTP_URL_STRIP_PASS', 'http://user@www.example.com:8080/pub/index.php?a=b#files'),
 			array('HTTP_URL_STRIP_AUTH', 'http://www.example.com:8080/pub/index.php?a=b#files'),
 			array('HTTP_URL_STRIP_PORT', 'http://user:pass@www.example.com/pub/index.php?a=b#files'),
-			array('HTTP_URL_STRIP_PATH', 'http://user:pass@www.example.com:8080?a=b#files'),
+			array('HTTP_URL_STRIP_PATH', 'http://user:pass@www.example.com:8080/?a=b#files'),
 			array('HTTP_URL_STRIP_QUERY', 'http://user:pass@www.example.com:8080/pub/index.php#files'),
 			array('HTTP_URL_STRIP_FRAGMENT', 'http://user:pass@www.example.com:8080/pub/index.php?a=b'),
-			array('HTTP_URL_STRIP_ALL', 'http://www.example.com'),
+			array('HTTP_URL_STRIP_ALL', 'http://www.example.com/'),
 		);
 	}
 }

--- a/tests/HttpBuildUrlTest.php
+++ b/tests/HttpBuildUrlTest.php
@@ -183,6 +183,7 @@ class HttpBuildUrlTest extends \PHPUnit_Framework_TestCase
 	public function pathProvider()
 	{
 		$url_minus_file = 'http://user:pass@www.example.com:8080/pub/?a=b#files';
+		$url_depth = 'http://user:pass@www.example.com:8080/pub1/pub2/pub3/?a=b#files';
 		return array(
 			array($this->full_url, '/donuts/brownies', 'http://user:pass@www.example.com:8080/donuts/brownies?a=b#files'),
 			array($this->full_url, 'chicken/wings', 'http://user:pass@www.example.com:8080/pub/chicken/wings?a=b#files'),
@@ -190,6 +191,11 @@ class HttpBuildUrlTest extends \PHPUnit_Framework_TestCase
 			array($url_minus_file, '/donuts/brownies', 'http://user:pass@www.example.com:8080/donuts/brownies?a=b#files'),
 			array($url_minus_file, 'chicken/wings', 'http://user:pass@www.example.com:8080/pub/chicken/wings?a=b#files'),
 			array($url_minus_file, 'sausage/bacon/', 'http://user:pass@www.example.com:8080/pub/sausage/bacon/?a=b#files'),
+			array($url_depth, '../donuts/brownies', 'http://user:pass@www.example.com:8080/pub1/pub2/donuts/brownies?a=b#files'),
+			array($url_depth, '/../donuts/brownies', 'http://user:pass@www.example.com:8080/donuts/brownies?a=b#files'),
+			array($url_depth, '../../donuts/brownies', 'http://user:pass@www.example.com:8080/pub1/donuts/brownies?a=b#files'),
+			array($url_depth, '../../../donuts/brownies', 'http://user:pass@www.example.com:8080/donuts/brownies?a=b#files'),
+
 		);
 	}
 

--- a/tests/HttpBuildUrlTest.php
+++ b/tests/HttpBuildUrlTest.php
@@ -151,9 +151,9 @@ class HttpBuildUrlTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * @dataProvider pathProvider
 	 */
-	public function testJoinPath($path, $expected)
+	public function testJoinPath($url, $path, $expected)
 	{
-		$actual = http_build_url($this->full_url, array('path' => $path), HTTP_URL_JOIN_PATH);
+		$actual = http_build_url($url, array('path' => $path), HTTP_URL_JOIN_PATH);
 
 		$this->assertSame($expected, $actual);
 	}
@@ -182,10 +182,14 @@ class HttpBuildUrlTest extends \PHPUnit_Framework_TestCase
 
 	public function pathProvider()
 	{
+		$url_minus_file = 'http://user:pass@www.example.com:8080/pub/?a=b#files';
 		return array(
-			array('/donuts/brownies', 'http://user:pass@www.example.com:8080/donuts/brownies?a=b#files'),
-			array('chicken/wings', 'http://user:pass@www.example.com:8080/pub/chicken/wings?a=b#files'),
-			array('sausage/bacon/', 'http://user:pass@www.example.com:8080/pub/sausage/bacon/?a=b#files')
+			array($this->full_url, '/donuts/brownies', 'http://user:pass@www.example.com:8080/donuts/brownies?a=b#files'),
+			array($this->full_url, 'chicken/wings', 'http://user:pass@www.example.com:8080/pub/chicken/wings?a=b#files'),
+			array($this->full_url, 'sausage/bacon/', 'http://user:pass@www.example.com:8080/pub/sausage/bacon/?a=b#files'),
+			array($url_minus_file, '/donuts/brownies', 'http://user:pass@www.example.com:8080/donuts/brownies?a=b#files'),
+			array($url_minus_file, 'chicken/wings', 'http://user:pass@www.example.com:8080/pub/chicken/wings?a=b#files'),
+			array($url_minus_file, 'sausage/bacon/', 'http://user:pass@www.example.com:8080/pub/sausage/bacon/?a=b#files'),
 		);
 	}
 

--- a/tests/HttpBuildUrlTest.php
+++ b/tests/HttpBuildUrlTest.php
@@ -26,6 +26,23 @@ class HttpBuildUrlTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($expected, $actual);
 	}
 
+	public function testExampleTwo()
+	{
+		$expected = 'ftp://ftp.example.com/pub/files/current/?a=c';
+		$actual   = http_build_url(
+			"http://user@www.example.com/pub/index.php#files",
+			array(
+				"scheme" => "ftp",
+				"host"   => "ftp.example.com",
+				"path"   => "files/current/",
+				"query"  => "a=c"
+			),
+			HTTP_URL_STRIP_AUTH | HTTP_URL_JOIN_PATH | HTTP_URL_STRIP_FRAGMENT
+		);
+
+		$this->assertSame($expected, $actual);
+	}
+
 	public function trailingSlashProvider()
 	{
 		return array(

--- a/tests/HttpBuildUrlTest.php
+++ b/tests/HttpBuildUrlTest.php
@@ -200,7 +200,7 @@ class HttpBuildUrlTest extends \PHPUnit_Framework_TestCase
 	public function pathProvider()
 	{
 		$url_minus_file = 'http://user:pass@www.example.com:8080/pub/?a=b#files';
-		$url_depth = 'http://user:pass@www.example.com:8080/pub1/pub2/pub3/?a=b#files';
+		$url_depth = 'http://user:pass@www.example.com:8080/path1/path2/path3/?a=b#files';
 		return array(
 			array($this->full_url, '/donuts/brownies', 'http://user:pass@www.example.com:8080/donuts/brownies?a=b#files'),
 			array($this->full_url, 'chicken/wings', 'http://user:pass@www.example.com:8080/pub/chicken/wings?a=b#files'),
@@ -208,10 +208,9 @@ class HttpBuildUrlTest extends \PHPUnit_Framework_TestCase
 			array($url_minus_file, '/donuts/brownies', 'http://user:pass@www.example.com:8080/donuts/brownies?a=b#files'),
 			array($url_minus_file, 'chicken/wings', 'http://user:pass@www.example.com:8080/pub/chicken/wings?a=b#files'),
 			array($url_minus_file, 'sausage/bacon/', 'http://user:pass@www.example.com:8080/pub/sausage/bacon/?a=b#files'),
-			array($url_depth, '../donuts/brownies', 'http://user:pass@www.example.com:8080/pub1/pub2/donuts/brownies?a=b#files'),
+			array($url_depth, '../donuts/brownies', 'http://user:pass@www.example.com:8080/path1/path2/donuts/brownies?a=b#files'),
 			array($url_depth, '/../donuts/brownies', 'http://user:pass@www.example.com:8080/donuts/brownies?a=b#files'),
-			array($url_depth, '../../donuts/brownies', 'http://user:pass@www.example.com:8080/pub1/donuts/brownies?a=b#files'),
-			array($url_depth, '../../../donuts/brownies', 'http://user:pass@www.example.com:8080/donuts/brownies?a=b#files'),
+			array($url_depth, '../../donuts/brownies', 'http://user:pass@www.example.com:8080/path1/donuts/brownies?a=b#files'),
 
 		);
 	}


### PR DESCRIPTION
I have compared PHP 5.5 with PECL HTTP 1.7.x installed and this current repo. I have corrected the differences so it behaves the same with regards to HTTP_URL_JOIN_QUERY, HTTP_URL_JOIN_PATHS and trailing slashes.
