### PR TITLE
Fix tests (episode 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: php
 php:
   - 5.2
@@ -5,12 +7,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7
+  - 7.0
+  - 7.1
   - hhvm
 
-before_install:
-    - phpenv global 5.5
-    - composer require codeclimate/php-test-reporter --dev
-    - phpenv global "$TRAVIS_PHP_VERSION"
-    
-script: ./vendor/bin/phpunit --coverage-text
+script: phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 
 language: php
 php:
-  - 5.2
   - 5.3
   - 5.4
   - 5.5

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,6 @@
     "issues": "https://github.com/jakeasmith/http_build_url/issues",
     "source": "https://github.com/jakeasmith/http_build_url"
   },
-  "require-dev": {
-    "phpunit/phpunit": "~3.7"
-  },
   "autoload": {
       "files": ["src/http_build_url.php"]
   }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
+<phpunit bootstrap="./tests/bootstrap.php" colors="true">
     <testsuites>
         <testsuite>
             <directory>./tests</directory>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+require dirname( __DIR__ ) . '/src/http_build_url.php';
+
+// PHPUnit 6 compatibility for previous versions
+if ( class_exists( 'PHPUnit\Runner\Version' ) && version_compare( PHPUnit\Runner\Version::id(), '6.0', '>=' ) ) {
+    class_alias( 'PHPUnit\Framework\Assert',        'PHPUnit_Framework_Assert' );
+    class_alias( 'PHPUnit\Framework\TestCase',      'PHPUnit_Framework_TestCase' );
+    class_alias( 'PHPUnit\Framework\Error\Error',   'PHPUnit_Framework_Error' );
+    class_alias( 'PHPUnit\Framework\Error\Notice',  'PHPUnit_Framework_Error_Notice' );
+    class_alias( 'PHPUnit\Framework\Error\Warning', 'PHPUnit_Framework_Error_Warning' );
+}
+
+// Past this point, tests will start


### PR DESCRIPTION
This PR fixes tests on Travis

I elected to:
- add PHP 7.1
- remove PHP 5.2 : while the lib presumably works on 5.2, it has become too much of a hassle to maintain compatibility for tests on Travis. I think you could mention on the README that it should work despite not being covered by tests, but you could also consider that 5.2 is dead anyway :)
- simplify and speed up the build : you were previously requiring a number of dependencies just for the tests (while your library doesn't have any) via `composer require codeclimate/php-test-reporter` in `before_install`, but yet nothing was actually used in `after_script`. Eventually I believe this was useless, except for the sole creation of an autoload file then only used to include your library. Your library is now included for tests in a very simple `bootstrap.php` file
- I added compatibility functions for PHPUnit (see `bootstrap.php`) to allow testing all versions of PHP without requiring a particular and outdate PHPUnit version as previously. Now each PHP version use their respective most up to date PHPUnit package.
